### PR TITLE
Codecov on main only

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,23 @@
+name: Codecov
+on:
+  push:
+    branches:
+      - main
+jobs:
+  build:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+      - name: Install Dependencies
+        run: yarn
+      - name: Run the tests
+        run: yarn workspace app test:coverage
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
+          files: ./app/coverage/*.json # optional
+          fail_ci_if_error: true # optional (default = false)
+          verbose: true # optional (default = false)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
-      - name: Install dependencies
+      - name: Install Dependencies
         run: yarn
       - name: Run the tests
         run: yarn workspace app test:coverage
-      - name: Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-          files: ./app/coverage/*.json # optional
-          fail_ci_if_error: true # optional (default = false)
-          verbose: true # optional (default = false)


### PR DESCRIPTION
Run codecov on commits to `main` only, because github secrets aren't shared with PR's from forks– so codecov fails and the workaround seems heavy-handed atm.