### PR TITLE
Decode Node/Edge labels

### DIFF
--- a/app/src/components/Graph.tsx
+++ b/app/src/components/Graph.tsx
@@ -301,9 +301,11 @@ function getCyStyleFromTheme(theme: typeof colors): CytoscapeOptions["style"] {
         "arrow-scale": 1,
         "curve-style": "bezier",
         label: "data(label)",
+
         color: theme.foreground,
         "font-size": 10,
         "text-valign": "center",
+        "text-wrap": "wrap",
         "font-family":
           "-apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif, Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol",
         "text-halign": "center",

--- a/app/src/components/TextResizer.module.css
+++ b/app/src/components/TextResizer.module.css
@@ -7,6 +7,7 @@
   width: 128px;
   display: inline-block;
   word-break: keep-all;
+  white-space: pre-wrap;
   font-family: -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif,
     Apple Color Emoji, Segoe UI Emoji, Segoe UI Symbol;
 }

--- a/app/src/utils.ts
+++ b/app/src/utils.ts
@@ -120,8 +120,8 @@ function getLineData(text: string, lineNumber: number) {
     nodeLabel.match(/^\((?<linkedId>.+)\)\s*$/) || {};
   const { linkedId } = labelGroups || {};
   return {
-    nodeLabel: nodeLabel.trim(),
-    edgeLabel: edgeLabel.trim(),
+    nodeLabel: decodeURIComponent(nodeLabel.trim()),
+    edgeLabel: decodeURIComponent(edgeLabel.trim()),
     indent,
     id,
     linkedId,


### PR DESCRIPTION
Decode each line as a URI component.
This allows for multi-line edge labels
And in the future could help support multi-line node labels... especially if we decide to allow markdown - but then we would probably need some way to edit individual lines as markdown so users don't need to leave the site to do the URI encoding
