### PR TITLE
Suggest the other term for 'Korean' translation

### DIFF
--- a/app/src/locales/i18n.tsx
+++ b/app/src/locales/i18n.tsx
@@ -9,7 +9,7 @@ export const languages = {
   en: "English",
   fr: "Français",
   hi: "हिन्दी",
-  ko: "조선말",
+  ko: "한국어",
   zh: "中文",
 };
 


### PR DESCRIPTION
Thanks for adding up Korean for your service.
However, can I suggest the other term for 'Korean' translation?

Although '조선말' which you chose for 'Korean' is correct, it uses in North Korea, DPRK.
In South Korea, ROK, we call our language as '한국어'.
I suggest changing 조선말 to 한국어 if you like.