### PR TITLE
no error for invalid line and then some

### DIFF
--- a/app/benchmarks/utils.results.json
+++ b/app/benchmarks/utils.results.json
@@ -1,5 +1,5 @@
 {
-  "parseText - one line": 625509,
-  "parseText - one edge": 152689,
-  "parseText - demo text": 15245
+  "parseText - one line": 511851,
+  "parseText - one edge": 288799,
+  "parseText - demo text": 33352
 }

--- a/app/benchmarks/utils.results.json
+++ b/app/benchmarks/utils.results.json
@@ -1,5 +1,5 @@
 {
-  "parseText - one line": 622715,
-  "parseText - one edge": 158931,
-  "parseText - demo text": 14907
+  "parseText - one line": 625509,
+  "parseText - one edge": 152689,
+  "parseText - demo text": 15245
 }

--- a/app/benchmarks/utils.ts
+++ b/app/benchmarks/utils.ts
@@ -47,16 +47,17 @@ suite
     console.log(String(event.target));
   })
   .on("complete", function () {
-    if (!process.env.CI && argv.write) {
+    if (!process.env.CI && !argv.compare && argv.write) {
       writeFileSync(resultsPath, JSON.stringify(runResults, null, "  "));
     }
 
-    if (process.env.CI) {
+    if (process.env.CI || argv.compare) {
       const prevResults = JSON.parse(readFileSync(resultsPath, "utf8"));
       for (const result in runResults) {
         if (result in prevResults) {
           const percentageDiff =
             (runResults[result] - prevResults[result]) / prevResults[result];
+          console.log(`${result}: ${percentageDiff * 100}%`);
           if (percentageDiff < -0.15) {
             console.error(`${result} is 15% slower than expected`);
             process.exit(1);

--- a/app/package.json
+++ b/app/package.json
@@ -76,7 +76,8 @@
     "e2e": "npx playwright test --config=playwright.config.ts",
     "generate:types": "export $(cat .env.local | xargs) && npx openapi-typescript \"${SB_URL}/rest/v1/?apikey=${SB_ANON_KEY}\" --output src/types/supabase.ts",
     "benchmark": "npx ts-node -O '{\"module\":\"commonjs\"}' --files benchmarks/utils.ts",
-    "benchmark:write": "yarn benchmark --write"
+    "benchmark:write": "yarn benchmark --write",
+    "benchmark:compare": "yarn benchmark --compare"
   },
   "eslintConfig": {
     "extends": [

--- a/app/src/components/EditorError.module.css
+++ b/app/src/components/EditorError.module.css
@@ -1,7 +1,8 @@
 .EditorError {
   position: absolute;
   bottom: 0;
-  right: 0;
-  color: red;
-  background-color: hsla(var(--color-backgroundHsl), 0.75);
+  right: var(--spacer-px);
+  left: var(--spacer-px);
+  bottom: var(--spacer-px);
+  color: black;
 }

--- a/app/src/components/EditorError.tsx
+++ b/app/src/components/EditorError.tsx
@@ -22,12 +22,16 @@ export default function EditorError() {
             className={styles.EditorError}
             flow="column"
             columnGap={1}
+            content="center start"
             items="center"
             p={2}
             rad={2}
+            background="palette-orange-0"
           >
             <BiErrorCircle size={24} />
-            <Type size={-1}>{show}</Type>
+            <Type size={-1} weight="700">
+              {show}
+            </Type>
           </Box>
         </motion.div>
       ) : null}

--- a/app/src/lib/utils.test.ts
+++ b/app/src/lib/utils.test.ts
@@ -210,6 +210,13 @@ describe("parseText", () => {
       },
     });
   });
+
+  it("should error labeled edges with no indent", () => {
+    const label = `A\ntest: B`;
+    expect(() => parseText(label, getSize)).toThrow(
+      "Line 2 has an edge label but no indent."
+    );
+  });
 });
 
 function nodesOnly(el: cytoscape.ElementDefinition) {

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -80,6 +80,15 @@ export function parseText(
           },
         });
       }
+    } else {
+      // No indent
+      if (edgeLabel) {
+        throw new Error(
+          `Line ${
+            lineNumber + startingLineNumber
+          } has an edge label but no indent.`
+        );
+      }
     }
     if (!linkedId) {
       // Check for custom id

--- a/app/src/lib/utils.ts
+++ b/app/src/lib/utils.ts
@@ -24,82 +24,75 @@ export function parseText(
 
   // break into lines
   const lines = text.split("\n");
+  const lineData: ReturnType<typeof getLineData>[] = [];
 
   // Loop over lines
-  for (const line of lines) {
-    if (line.trim() === "") {
-      lineNumber++;
-      continue;
-    }
-    const { linkedId, nodeLabel, edgeLabel, indent, id } = getLineData(
-      line,
-      lineNumber
-    );
+  for (const lineStr of lines) {
+    lineData[lineNumber] = getLineData(lineStr, lineNumber);
+    const line = lineData[lineNumber];
+    if (line) {
+      const { linkedId, nodeLabel, edgeLabel, indent, id } = line;
 
-    if (indent) {
-      let parent;
-      let checkLine = lineNumber;
+      if (indent) {
+        let parent, lineNumberToCheck;
 
-      while (checkLine >= 1) {
-        checkLine -= 1;
-        const currentLine = lines[checkLine - 1];
+        for (
+          lineNumberToCheck = lineNumber - 1;
+          lineNumberToCheck >= 1;
+          lineNumberToCheck--
+        ) {
+          const lineToCheck = lineData[lineNumberToCheck];
+          if (!lineToCheck) continue;
 
-        /* Determine whether valid line */
-        if (currentLine.trim() === "") {
-          continue;
+          if (lineToCheck.indent.length < indent.length) {
+            parent = lineData[lineNumberToCheck];
+            break;
+          }
         }
 
-        const { indent: currentLineIndent } = getLineData(
-          currentLine,
-          checkLine
-        );
-        if (currentLineIndent.length < indent.length) {
-          parent = checkLine;
-          break;
+        // If we found a parent
+        if (parent) {
+          const source = parent.id;
+          const target = linkedId || line.id;
+
+          // Find a unique id
+          let id = `${source}_${target}:0`;
+          while (elements.map(({ data: { id } }) => id).includes(id)) {
+            let [, count] = id.split(":");
+            count = (parseInt(count, 10) + 1).toString();
+            id = `${source}_${target}:${count}`;
+          }
+          elements.push({
+            data: {
+              id,
+              source,
+              target,
+              label: edgeLabel,
+              lineNumber: lineNumber + startingLineNumber,
+            },
+          });
+        }
+      } else {
+        // No indent
+        if (edgeLabel) {
+          throw new Error(
+            `Line ${
+              lineNumber + startingLineNumber
+            } has an edge label but no indent.`
+          );
         }
       }
-      // If we found a parent
-      if (parent) {
-        const { id: source } = getLineData(lines[checkLine - 1], checkLine);
-        const target = linkedId || getLineData(line, lineNumber).id;
-
-        // Find a unique id
-        let id = `${source}_${target}:0`;
-        while (elements.map(({ data: { id } }) => id).includes(id)) {
-          let [, count] = id.split(":");
-          count = (parseInt(count, 10) + 1).toString();
-          id = `${source}_${target}:${count}`;
-        }
+      if (!linkedId) {
+        // Check for custom id
         elements.push({
           data: {
             id,
-            source,
-            target,
-            label: edgeLabel,
+            label: nodeLabel,
             lineNumber: lineNumber + startingLineNumber,
+            ...getSize(nodeLabel),
           },
         });
       }
-    } else {
-      // No indent
-      if (edgeLabel) {
-        throw new Error(
-          `Line ${
-            lineNumber + startingLineNumber
-          } has an edge label but no indent.`
-        );
-      }
-    }
-    if (!linkedId) {
-      // Check for custom id
-      elements.push({
-        data: {
-          id,
-          label: nodeLabel,
-          lineNumber: lineNumber + startingLineNumber,
-          ...getSize(nodeLabel),
-        },
-      });
     }
     lineNumber++;
   }
@@ -148,6 +141,7 @@ export function parseText(
 }
 
 function getLineData(text: string, lineNumber: number) {
+  if (text.trim() === "") return;
   // Whole line description in one regex with named capture groups
   // 1) Indent ^(?<indent>\s*) -- store the indent which is 0 or more whitespace at the start
   // 2) ID (\[(?<id>.*)\])? -- store the ID if it exists after the indent in square brackets


### PR DESCRIPTION
- throw error on invalid edge
- add `yarn workspace app benchmark:compare` to check locally
- don't parse line data more than once 🏎