### PR TITLE
fix: order-history auth

### DIFF
--- a/api/order-history.ts
+++ b/api/order-history.ts
@@ -1,12 +1,18 @@
 import { VercelRequest, VercelResponse } from "@vercel/node";
-import { isError } from "./_lib/_helpers";
+import { isError, getCustomerFromToken } from "./_lib/_helpers";
 import { stripe } from "./_lib/_stripe";
 
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   try {
+    const token = req.headers.authorization;
+    const customer = await getCustomerFromToken(token);
+
+    if (!customer) {
+      return res.status(401).json({ error: { message: "Unauthorized" } });
+    }
+
     const { data: invoices } = await stripe.invoices.list({
-      customer: req.body.customerId,
-      subscription: req.body.subscriptionId,
+      customer: customer.id,
     });
 
     res.json({ invoices });


### PR DESCRIPTION
Adds missing authentication check to the order-history API endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)