### PR TITLE
fix: send auth token to order-history endpoint

### DIFF
--- a/app/src/lib/queries.ts
+++ b/app/src/lib/queries.ts
@@ -88,15 +88,16 @@ async function orderHistory(
   }[]
 > {
   if (!customerId || !subscriptionId) return [];
+  if (!supabase) return [];
+  const auth = await supabase.auth.getSession();
+  if (!auth.data.session) return [];
+  const accessToken = auth.data.session.access_token;
   const response = await fetch("/api/order-history", {
     method: "post",
     headers: {
       "Content-Type": "application/json",
+      Authorization: `Bearer ${accessToken}`,
     },
-    body: JSON.stringify({
-      customerId,
-      subscriptionId,
-    }),
   });
   const { error, invoices } = await response.json();
   if (error) throw error;


### PR DESCRIPTION
## Summary

- `orderHistory()` in `app/src/lib/queries.ts` was not sending an `Authorization` header to `/api/order-history`
- Commit `d542fd7` updated the API to require token-based auth (via `getCustomerFromToken()`), but the frontend was never updated to match
- This caused every account page visit to return a 402 "No token provided" error

## Fix

Mirrors the existing `customerInfo()` pattern: get the Supabase session and pass `Bearer ${accessToken}` in the request header. Removes the now-unused `customerId`/`subscriptionId` from the request body.

## Test plan

- [ ] Log in as a pro user and navigate to `/a` (Account page)
- [ ] Confirm order history loads without errors
- [ ] Confirm `/api/order-history` returns 200 in the network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)