### PR TITLE
Stabilize flaky pro CSV-import e2e test

### DIFF
--- a/app/e2e/pro.spec.ts
+++ b/app/e2e/pro.spec.ts
@@ -153,11 +153,18 @@ test("Create chart from imported data", async () => {
       .selectOption("Connector Label");
     await page.getByTestId("import-submit-button").click();
 
+    // Import parsing + preview can be slow against the Vercel preview, so give
+    // the confirmation dialog generous time rather than the 5s default (this
+    // assertion has flaked at the default timeout).
     await expect(
       page.getByText("You are about to add 9 nodes and 10 edges to your graph.")
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30000 });
 
-    await page.getByTestId("import-confirm-button").click();
+    // Wait for the confirm button to be actionable before clicking — this click
+    // has hung to the test timeout when the dialog was still settling.
+    const confirmButton = page.getByTestId("import-confirm-button");
+    await confirmButton.waitFor({ state: "visible", timeout: 30000 });
+    await confirmButton.click();
   } catch (error) {
     console.error(error);
     throw error;

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -33,6 +33,11 @@ const config: PlaywrightTestConfig = {
     },
   },
   maxFailures: 3,
+  // E2E runs against a live Vercel preview; some flows (notably the CSV-import
+  // confirmation in pro.spec) are timing-sensitive there. Retry in CI so a
+  // one-off flake doesn't redden the whole PR — a real break still fails every
+  // attempt. Locally retries stay off so flakes stay visible while developing.
+  retries: isCI ? 2 : 0,
   projects: isDebug
     ? [
         {


### PR DESCRIPTION
`pro.spec.ts:118` ("Create chart from imported data") has flaked ~4x across recent PRs (#804, #805), always in the CSV import → confirm flow against the Vercel preview — never a product bug:
- sometimes the "9 nodes and 10 edges" confirmation didn't appear within the 5s default (line 158),
- sometimes the confirm click hung to the 120s test timeout (line 160).

## Fix
1. **Targeted waits** — bump the confirmation `toBeVisible` to 30s (import parsing is slow against the preview) and wait for the confirm button to be actionable before clicking (so it can't hang to the test timeout).
2. **CI retries** (`retries: isCI ? 2 : 0`) — the standard mitigation for e2e against a live preview. Every failure was a single-attempt flake, so a retry absorbs it; a real break still fails all attempts and stays red. Local retries stay **off** so flakes remain visible while developing.

## Honest caveat
This can't be *proven* in a single run — the test only flakes against CI/preview and passes locally. Verification is a reduced flake rate over subsequent CI runs. Retries alone would have turned all 4 recent failures green.

This is a pragmatic stabilizer; the deeper fix (less preview-timing-dependent e2e) comes with the eventual CRA→Vite/framework migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)